### PR TITLE
Set default hostname if port is set

### DIFF
--- a/src/devTools.js
+++ b/src/devTools.js
@@ -33,6 +33,10 @@ function watch() {
 export function start(options) {
   if (options) {
     instanceName = options.name;
+
+    if (options.port && !options.hostname) {
+      options.hostname = 'localhost';
+    }
   }
   connect(options && options.port ? options : socketOptions);
 }


### PR DESCRIPTION
If I haven't set `hostname`, will throw the following error:

```
Uncaught SyntaxError: Failed to construct 'WebSocket': The URL 'ws://:5678/socketcluster/' is invalid.
```