### PR TITLE
Do not crash on socket errors

### DIFF
--- a/src/devTools.js
+++ b/src/devTools.js
@@ -47,6 +47,9 @@ function connectToServer(options) {
     };
   } else socketOptions = defaultSocketOptions;
   socket = socketCluster.create(socketOptions);
+  socket.on('error', err => {
+    console.error("Error in removedev-socket", err);
+  });
   watch();
 }
 

--- a/src/devTools.js
+++ b/src/devTools.js
@@ -48,7 +48,7 @@ function connectToServer(options) {
   } else socketOptions = defaultSocketOptions;
   socket = socketCluster.create(socketOptions);
   socket.on('error', err => {
-    console.error("Error in removedev-socket", err);
+    console.error('Error in removedev-socket', err);
   });
   watch();
 }


### PR DESCRIPTION
when running unit test suites on node without listening to this event the test runner crashes after all tests are run successfully.